### PR TITLE
Update Mac install instructions for easier installation on macOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,10 +99,10 @@
           <img class="logo mac" alt="mac os x logo" src="mac.svg" />
           <h3>Mac OS X</h3>
           <p>
-            Download the <a class="download mac" href="https://github.com/portacle/portacle/releases/download/1.4/mac-portacle.dmg">latest release</a> and extract it. Due to "security" reasons on OS X you must then move the <code>Portacle.app</code> within the extracted directory into another directory like <code>projects/</code> and back again using Finder. From then on you can launch it by double-clicking the <code>Portacle.app</code>. The first time you launch it, OS X is going to block the application as it is "from an unidentified developer." You need to open System Preferences, go to Security, and click the Open Anyway button to mark the application as trusted. After that it should work straight away.
+            Download the <a class="download mac" href="https://github.com/portacle/portacle/releases/download/1.4/mac-portacle.dmg">latest release</a>, open the disk image, and move it to a dirctory such as `/Applications`. Due to "security" reasons on macOS, you'll then need to run <pre>sudo xattr -dr com.apple.quarantine /Applications/portacle</pre> in order to remove the quarantine attribute from all files in the `portacle` directory. This will allow you to open the application without security warnings.
           </p>
           <p>
-            Note that you cannot copy the <code>Portacle.app</code> outside of the <code>portacle</code> directory. You must take the whole directory with you. You can however drag the app into your dock.
+            Note that you cannot copy the <code>Portacle.app</code> outside of the <code>portacle</code> directory. You must take the whole directory with you. You can however drag the app into your dock to create a shortcut.
           </p>
         </article>
         <article id="get-lin">

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
           <img class="logo mac" alt="mac os x logo" src="mac.svg" />
           <h3>Mac OS X</h3>
           <p>
-            Download the <a class="download mac" href="https://github.com/portacle/portacle/releases/download/1.4/mac-portacle.dmg">latest release</a>, open the disk image, and move it to a dirctory such as `/Applications`. Due to "security" reasons on macOS, you'll then need to run <pre>sudo xattr -dr com.apple.quarantine /Applications/portacle</pre> in order to remove the quarantine attribute from all files in the `portacle` directory. This will allow you to open the application without security warnings.
+            Download the <a class="download mac" href="https://github.com/portacle/portacle/releases/download/1.4/mac-portacle.dmg">latest release</a>, open the disk image, and move the `portacle` folder to a dirctory such as `/Applications` for easy access. Due to "security" reasons on macOS, you'll then need to run <pre>sudo xattr -dr com.apple.quarantine /Applications/portacle</pre> (replace `/Applications` with whatever path you moved your `portacle` directory to) in order to remove the quarantine attribute from all files in the `portacle` directory. This will allow you to open the application without security warnings/confirmations.
           </p>
           <p>
             Note that you cannot copy the <code>Portacle.app</code> outside of the <code>portacle</code> directory. You must take the whole directory with you. You can however drag the app into your dock to create a shortcut.

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
           <img class="logo mac" alt="mac os x logo" src="mac.svg" />
           <h3>Mac OS X</h3>
           <p>
-            Download the <a class="download mac" href="https://github.com/portacle/portacle/releases/download/1.4/mac-portacle.dmg">latest release</a>, open the disk image, and move the `portacle` folder to a dirctory such as `/Applications` for easy access. Due to "security" reasons on macOS, you'll then need to run <pre>sudo xattr -dr com.apple.quarantine /Applications/portacle</pre> (replace `/Applications` with whatever path you moved your `portacle` directory to) in order to remove the quarantine attribute from all files in the `portacle` directory. This will allow you to open the application without security warnings/confirmations.
+            Download the <a class="download mac" href="https://github.com/portacle/portacle/releases/download/1.4/mac-portacle.dmg">latest release</a>, open the disk image, and move the `portacle` folder to a dirctory such as `/Applications` for easy access. Due to "security" reasons on macOS, you'll then need to run <pre>sudo xattr -dr com.apple.quarantine /Applications/portacle</pre> (replace `/Applications` with whatever path you moved your `portacle` directory to) in order to remove the quarantine attribute from all files in the `portacle` directory. This will allow you to open the application without security warnings/confirmations. You may see several <pre>xattr: No such file</pre> errors, which can be safely ignored.
           </p>
           <p>
             Note that you cannot copy the <code>Portacle.app</code> outside of the <code>portacle</code> directory. You must take the whole directory with you. You can however drag the app into your dock to create a shortcut.


### PR DESCRIPTION
For details, see my comment here: https://github.com/portacle/portacle/issues/153#issuecomment-1483679197

I feel like this provides simpler and more streamlined install instructions for macOS users. 😄 